### PR TITLE
Another batch of bug fixes and improvements

### DIFF
--- a/src/editorui/editormain.py
+++ b/src/editorui/editormain.py
@@ -764,6 +764,10 @@ class KPEditorWidget(QtWidgets.QGraphicsView):
 
                 self.scene().clearSelection()
 
+                if isinstance(itemsUnder[0], (KPEditorNode, KPEditorPath)):
+                    QtWidgets.QGraphicsView.mousePressEvent(self, event)
+                    return
+
                 kLayer = itemsUnder[0]._layerRef()
                 if isinstance(kLayer, (KPPathTileLayer, KPPathLayer)):
                     QtWidgets.QGraphicsView.mousePressEvent(self, event)

--- a/src/editorui/editormain.py
+++ b/src/editorui/editormain.py
@@ -517,7 +517,7 @@ class KPEditorWidget(QtWidgets.QGraphicsView):
                     selected = self.scene().selectedItems()
 
                     for selItem in selected:
-                        if isinstance(item, KPEditorNode) and selItem != item:
+                        if isinstance(item, KPEditorNode) and selItem != item and not isinstance(selItem, KPEditorPath):
                             sourceItem = selItem
                             sourceNode = selItem._nodeRef()
                             break

--- a/src/mapdata.py
+++ b/src/mapdata.py
@@ -608,6 +608,10 @@ class KPMap(object):
         else:
             self.version = 1
 
+        # Automatically set next key ID to the existing world count
+        if len(self.worlds) > 0:
+            self.nextWorldKey = len(self.worlds) + 1
+
         self.deleteNullDoodads()
         self.checkDoodadSizes()
 
@@ -657,6 +661,11 @@ class KPMap(object):
     def allocateWorldDefKey(self):
         key = self.nextWorldKey
         self.nextWorldKey += 1
+        return key
+
+    def freeWorldDefKey(self):
+        key = self.nextWorldKey
+        self.nextWorldKey -= 1
         return key
 
     def deleteNullDoodads(self):

--- a/src/mapdata.py
+++ b/src/mapdata.py
@@ -713,7 +713,7 @@ class KPMap(object):
         # we don't want to just outright delete them. So instead just warn the user.
         if dispWarning:
             listStr = "<br>".join(doodadDefList)
-            msg = 'One or more doodads present in the map exceed a size of 1024x1024 pixels. Doodads larger than this are known to cause issues in some cases, ' \
+            msg = 'One or more doodads present in the map exceed a width or height of 1024 pixels of 1024 pixels. Doodads larger than this are known to cause issues in some cases, ' \
                   'and may result in the map crashing in-game.<br><br>The following doodads were found to exceed this size:<br>' + listStr
             QtWidgets.QMessageBox.warning(None, 'Warning', msg)
 

--- a/src/mapdata.py
+++ b/src/mapdata.py
@@ -609,6 +609,7 @@ class KPMap(object):
             self.version = 1
 
         self.deleteNullDoodads()
+        self.checkDoodadSizes()
 
     def _dump(self, mapObj, dest):
         dest['version'] = self.version
@@ -684,6 +685,28 @@ class KPMap(object):
                 self.doodadDefinitions.pop(i)
             else:
                 i += 1
+
+    def checkDoodadSizes(self):
+        """Check all doodads to see if they're too large for the game
+        to handle (larger than 1024x1024px)"""
+
+        doodadDefList = []
+        dispWarning = False
+
+        # Check for doodads too large for the game to handle
+        for i in range(len(self.doodadDefinitions)):
+            doodadDef = self.doodadDefinitions[i]
+            if doodadDef[1].width() > 1024 or doodadDef[1].height() > 1024:
+                doodadDefList.append(doodadDef[0])
+                dispWarning = True
+
+        # Since some maps *can* have larger doodads and somehow get away with it,
+        # we don't want to just outright delete them. So instead just warn the user.
+        if dispWarning:
+            listStr = "<br>".join(doodadDefList)
+            msg = 'One or more doodads present in the map exceed a size of 1024x1024 pixels. Doodads larger than this are known to cause issues in some cases, ' \
+                  'and may result in the map crashing in-game.<br><br>The following doodads were found to exceed this size:<br>' + listStr
+            QtWidgets.QMessageBox.warning(None, 'Warning', msg)
 
     # LAYERS
     class LayerModel(QtCore.QAbstractListModel):

--- a/src/mapdata.py
+++ b/src/mapdata.py
@@ -713,7 +713,7 @@ class KPMap(object):
         # we don't want to just outright delete them. So instead just warn the user.
         if dispWarning:
             listStr = "<br>".join(doodadDefList)
-            msg = 'One or more doodads present in the map exceed a width or height of 1024 pixels of 1024 pixels. Doodads larger than this are known to cause issues in some cases, ' \
+            msg = 'One or more doodads present in the map exceed a width or height of 1024 pixels. Doodads larger than this are known to cause issues in some cases, ' \
                   'and may result in the map crashing in-game.<br><br>The following doodads were found to exceed this size:<br>' + listStr
             QtWidgets.QMessageBox.warning(None, 'Warning', msg)
 

--- a/src/ui.py
+++ b/src/ui.py
@@ -576,6 +576,11 @@ class KPDoodadSelector(QtWidgets.QWidget):
                 pix = QtGui.QPixmap()
                 pix.load(image)
 
+                # Prevent the user from adding doodads that the game cannot handle
+                if pix.width() > 1024 or pix.height() > 1024:
+                    QtWidgets.QMessageBox.warning(None, 'Warning', 'The doodad you tried to add is too large. Doodads can be no larger than 1024x1024 pixels.')
+                    return
+
                 KP.map.addDoodad(name, pix)
 
     def removeDoodad(self):

--- a/src/ui.py
+++ b/src/ui.py
@@ -1132,7 +1132,7 @@ class KPMainWindow(QtWidgets.QMainWindow):
         f = mb.addMenu('&File')
         self.fa = f.addAction('New',                        self.newMap, QKeySequence("Ctrl+N"))
         self.fb = f.addAction('Open...',                    self.openMap, QKeySequence("Ctrl+O"))
-        self.fc = f.addAction('Open Recent')                #
+        #self.fc = f.addAction('Open Recent')                #
         f.addSeparator()
         self.fd = f.addAction('Save',                       self.saveMap, QKeySequence("Ctrl+S"))
         self.fe = f.addAction('Save As...',                 self.saveMapAs, QKeySequence("Ctrl+Shift+S"))
@@ -1146,7 +1146,7 @@ class KPMainWindow(QtWidgets.QMainWindow):
 
         e = mb.addMenu('Edit')
         self.ea = e.addAction('Copy',                       self.copy, QKeySequence.Copy)
-        self.eb = e.addAction('Cut')                        # X
+        #self.eb = e.addAction('Cut')                        # X
         self.ec = e.addAction('Paste',                      self.paste, QKeySequence.Paste)
         e.addSeparator()
         self.ed = e.addAction('Select All',                 self.selectAll, QKeySequence.SelectAll)

--- a/src/ui.py
+++ b/src/ui.py
@@ -1201,6 +1201,10 @@ class KPMainWindow(QtWidgets.QMainWindow):
         doodadAction.setShortcut(QKeySequence("Ctrl+3"))
         w.addAction(doodadAction)
 
+        pathNodeAction = self.pathNodeDock.toggleViewAction()
+        pathNodeAction.setShortcut(QKeySequence("Ctrl+4"))
+        w.addAction(pathNodeAction)
+
         h = mb.addMenu('Help')
         self.ha = h.addAction('About Koopatlas',            self.aboutDialog)
         self.hb = h.addAction('Koopatlas Documentation',    self.goToHelp)

--- a/src/ui.py
+++ b/src/ui.py
@@ -175,6 +175,9 @@ class KPPathNodeList(QtWidgets.QWidget):
 
     def removeFolder(self):
         item = self.tree.currentItem()
+        if item is None:
+            return
+
         if not isinstance(item, self.KPPathNodeItem):
             kids = item.takeChildren()
             parent = item.parent()

--- a/src/ui.py
+++ b/src/ui.py
@@ -576,10 +576,10 @@ class KPDoodadSelector(QtWidgets.QWidget):
                 pix = QtGui.QPixmap()
                 pix.load(image)
 
-                # Prevent the user from adding doodads that the game cannot handle
+                # Warn the user when adding doodads that are generally too large
                 if pix.width() > 1024 or pix.height() > 1024:
-                    QtWidgets.QMessageBox.warning(None, 'Warning', 'The doodad you tried to add is too large. Doodads can be no larger than 1024x1024 pixels.')
-                    return
+                    QtWidgets.QMessageBox.warning(None, 'Warning', 'The file "' + name + '" exceeds a size of 1024x1024 pixels. Doodads of this size are known to cause ' \
+                                                                    'maps to crash in some cases, so consider shrinking the size of your image.')
 
                 KP.map.addDoodad(name, pix)
 

--- a/src/ui.py
+++ b/src/ui.py
@@ -578,7 +578,7 @@ class KPDoodadSelector(QtWidgets.QWidget):
 
                 # Warn the user when adding doodads that are generally too large
                 if pix.width() > 1024 or pix.height() > 1024:
-                    QtWidgets.QMessageBox.warning(None, 'Warning', 'The file "' + name + '" exceeds a size of 1024x1024 pixels. Doodads of this size are known to cause ' \
+                    QtWidgets.QMessageBox.warning(None, 'Warning', 'The file "' + name + '" exceeds a width or height of 1024 pixels. Doodads of this size are known to cause ' \
                                                                     'maps to crash in some cases, so consider shrinking the size of your image.')
 
                 KP.map.addDoodad(name, pix)

--- a/src/ui.py
+++ b/src/ui.py
@@ -653,7 +653,6 @@ class KPObjectSelector(QtWidgets.QWidget):
 
         # Borrowed the signals and junk from Reggie, figure we'll need em'
         # Some more signals are set in setTileset
-        self.listView.clicked.connect(self.handleObjReplace)
         self.sorterMenu.aboutToShow.connect(self.fixUpMenuSize)
         self.sorterMenu.triggered.connect(self.toggleTopLevel)
 
@@ -744,16 +743,7 @@ class KPObjectSelector(QtWidgets.QWidget):
 
         self.objChanged.emit(self.tileset.objects.index(object), object)
 
-    def handleObjReplace(self, index):
-        """Throws a signal when the selected object is used as a replacement"""
-        if QtWidgets.QApplication.keyboardModifiers() == QtCore.Qt.AltModifier:
-            i = current.row()
-            object, depth = self.model.groupItem().getItem(i)
-
-            self.objReplaced.emit(self.tileset.objects.index(object), object)
-
     objChanged = QtCore.pyqtSignal(int, KPTileObject)
-    objReplaced = QtCore.pyqtSignal(int, KPTileObject)
 
 
 class KPAnmOptions(QtWidgets.QWidget):

--- a/src/worldeditor.py
+++ b/src/worldeditor.py
@@ -157,6 +157,7 @@ class KPWorldTableModel(QtCore.QAbstractTableModel):
                 self.beginRemoveRows(parent, row, row+count-1)
                 for i in range(count):
                     del self.worlds[row]
+                self.currentMap.freeWorldDefKey()
                 self.endRemoveRows()
 
 


### PR DESCRIPTION
This fixes more bugs and improves some stuff, since Koopatlas can never have enough of that it seems:
- Fixed a crash that happens when right-clicking a node while having a path selected
- Fixed a crash when Ctrl clicking on a path or node
- Fixed a crash when pressing Delete Folder in the Path/Node Layers dock, while not having any folders selected
- Fixed a crash when Alt clicking on a tile object (caused by an unfinished object replacement feature)
- Fixed issues with the "key" (index) values of worlds in the World Editor (they now properly increment/decrement)

This also makes some minor improvements:
- Added a menubar action to toggle the Path/Node Layers dock (since it could be closed with no way of showing it again)
- Removed menubar actions that don't have any functionality (those being "Open Recent" and "Cut")
- Added warnings when importing doodads with a width/height greater than 1024 pixels, as this size is known to sometimes cause issues in-game
  - Additionally, a similar warning will be shown when loading the map in the editor